### PR TITLE
[xcvrd] Change in xcvrd ports cache creation, now ports are being fetched from config DB

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -1193,9 +1193,8 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 (platform_path, hwsku_path) = device_info.get_paths_to_platform_and_hwsku_dirs()
                 platform_sfputil.read_all_porttab_mappings(hwsku_path, self.num_asics)
             else:
-                # For single ASIC platforms we pass port_config_file_path and the asic_inst as 0
-                port_config_file_path = device_info.get_path_to_port_config_file()
-                platform_sfputil.read_porttab_mappings(port_config_file_path, 0)
+                # For single ASIC platforms we pass asic_inst 0
+                platform_sfputil.read_porttab_mappings(None, asic_inst=0, get_ports_from_db=True)
         except Exception, e:
             self.log_error("Failed to read port info: %s" % (str(e)), True)
             sys.exit(PORT_CONFIG_LOAD_ERROR)


### PR DESCRIPTION
[xcvrd] Change in xcvrd ports cache creation, now ports are being fetched from config DB.

**- Dependencies**
https://github.com/liorghub/sonic-platform-common/pull/1

Signed-off-by: liora <liora@nvidia.com>

**- Why I did it**
Fix community issue https://github.com/Azure/sonic-platform-daemons/issues/110
Issue description: newly created ports as part of dynamic port breakout process are not being added to XCVRD cache, hence not shown in SNMP get on entPhysicalEntry mib.

**- How I did it**
Add new option in XCVRD ports cache creation, fetch ports from config DB instead of port_config.ini

**- How to verify it**
SNMP walk on entPhysicalTable after static port breakout.

**- Which release branch to backport (provide reason below if selected)**
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
