### PR TITLE
[syseepromd] Decrease verbosity of eeprom load operation failure

### DIFF
--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -121,8 +121,7 @@ class DaemonSyseeprom(daemon_base.DaemonBase):
             self.chassis = sonic_platform.platform.Platform().get_chassis()
             self.eeprom = self.chassis.get_eeprom()
         except Exception as e:
-            self.log_warning(
-                "Failed to load platform-specific eeprom from sonic_platform package due to {}".format(repr(e)))
+            self.log_notice("Failed to load eeprom from sonic_platform package due to {}, retrying using plugin method".format(repr(e)))
 
         # If we didn't successfully load the class from the sonic_platform package, try loading the old plugin
         if not self.eeprom:


### PR DESCRIPTION
[syseepromd] Decrease verbosity of eeprom load operation failure since we retry using plugin method

Signed-off-by: liora <liora@nvidia.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
syseepromd is loading data from eeprom.
When syseepromd fails to load data from eeprom using the new platform API, it tries again using the old plugins way.
In the case where the first method fails, no need for warning in log since we try again using the plugins way.
If plugins  way will fail, error will be printed to log.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Remove unnecessary and confusing warning from log.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
I ran syseepromd  manually and verifed that the  message is being printed in notice verbosity.

#### Which release branch to backport
- [ ] 201811
- [x] 201911
- [ ] 202006
- [x] 202012
